### PR TITLE
Fix build workflow in npm publish

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -9,15 +9,31 @@ on:
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm i --package-lock-only
-      - run: npm ci
-      - run: npm test
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: "Start MySQL server"
+      run: sudo service mysql start
+    
+    - name: Clean install dependencies and build
+      run: |
+        npm i --package-lock-only
+        npm ci
+        npm run build --if-present
+    
+    - name: Run tests
+      run: npm test
 
   publish-npm:
     needs: build


### PR DESCRIPTION
# What this PR addresses:
Fix publishing build process to use MySQL and complete testing for multiple Nodejs versions