### PR TITLE
Add port parameter to mysql DB load

### DIFF
--- a/__tests__/environment/mysqlConfigParameters.js
+++ b/__tests__/environment/mysqlConfigParameters.js
@@ -1,0 +1,91 @@
+const exec = require("child_process").exec;
+const { importCreationScript } = require("../../databaseSetup");
+jest.mock("child_process");
+
+let execMethod;
+beforeAll(async () => {
+    exec.mockImplementation((commandString, config, callback) => {
+        const error = new Error("exec error");
+        const stdout = null;
+        const stderr = "stderr";
+        callback(error, stdout, stderr);
+
+        execMethod = jest.fn();
+        execMethod(commandString);
+    });
+});
+
+
+it("Check DB config using Host & User only ", async () => {
+    const globalConfig = require("../../tests/configs/default.js");
+    const dummyMysqlConfig = {
+        host: "127.0.0.1",
+        user: "root",
+    };
+    const dummyPathToCreationScript = "FILE";
+    await expect(
+        importCreationScript(dummyMysqlConfig, dummyPathToCreationScript)
+    ).rejects.toBe("stderr");
+    expect(execMethod).toHaveBeenCalledWith('mysql -h 127.0.0.1 -u root  < FILE');
+});
+
+it("Check DB config using Port ", async () => {
+    const globalConfig = require("../../tests/configs/default.js");
+    const dummyMysqlConfig = {
+        host: "127.0.0.1",
+        port: 3306,
+        user: "root",
+    };
+    const dummyPathToCreationScript = "FILE2";
+    await expect(
+        importCreationScript(dummyMysqlConfig, dummyPathToCreationScript)
+    ).rejects.toBe("stderr");
+    expect(execMethod).toHaveBeenCalledWith('mysql -h 127.0.0.1 -u root -P 3306  < FILE2');
+});
+
+
+it("Check DB config using password ", async () => {
+    const globalConfig = require("../../tests/configs/default.js");
+    const dummyMysqlConfig = {
+        host: "127.0.0.1",
+        user: "root",
+        password: "superSecret",
+    };
+    const dummyPathToCreationScript = "FILE";
+    await expect(
+        importCreationScript(dummyMysqlConfig, dummyPathToCreationScript)
+    ).rejects.toBe("stderr");
+    expect(execMethod).toHaveBeenCalledWith('mysql -h 127.0.0.1 -u root -psuperSecret  < FILE');
+});
+
+
+it("Check DB config using database parameter ", async () => {
+    const globalConfig = require("../../tests/configs/default.js");
+    const dummyMysqlConfig = {
+        host: "127.0.0.1",
+        user: "root",
+        database: "jest_mysql_test",
+    };
+    const dummyPathToCreationScript = "FILE";
+    await expect(
+        importCreationScript(dummyMysqlConfig, dummyPathToCreationScript)
+    ).rejects.toBe("stderr");
+    expect(execMethod).toHaveBeenCalledWith('mysql -h 127.0.0.1 -u root jest_mysql_test < FILE');
+});
+
+
+it("Check seven part config ", async () => {
+    const globalConfig = require("../../tests/configs/default.js");
+    const dummyMysqlConfig = {
+        host: "127.0.0.1",
+        port: 3306,
+        user: "root",
+        password: "root",
+        database: "jest_mysql_test"
+    };
+    const dummyPathToCreationScript = "FILE";
+    await expect(
+        importCreationScript(dummyMysqlConfig, dummyPathToCreationScript)
+    ).rejects.toBe("stderr");
+    expect(execMethod).toHaveBeenCalledWith('mysql -h 127.0.0.1 -u root -proot -P 3306 jest_mysql_test < FILE');
+});

--- a/__tests__/environment/mysqlConfigParameters.js
+++ b/__tests__/environment/mysqlConfigParameters.js
@@ -17,7 +17,6 @@ beforeAll(async () => {
 
 
 it("Check DB config using Host & User only ", async () => {
-    const globalConfig = require("../../tests/configs/default.js");
     const dummyMysqlConfig = {
         host: "127.0.0.1",
         user: "root",
@@ -30,7 +29,6 @@ it("Check DB config using Host & User only ", async () => {
 });
 
 it("Check DB config using Port ", async () => {
-    const globalConfig = require("../../tests/configs/default.js");
     const dummyMysqlConfig = {
         host: "127.0.0.1",
         port: 3306,
@@ -45,7 +43,6 @@ it("Check DB config using Port ", async () => {
 
 
 it("Check DB config using password ", async () => {
-    const globalConfig = require("../../tests/configs/default.js");
     const dummyMysqlConfig = {
         host: "127.0.0.1",
         user: "root",
@@ -60,7 +57,6 @@ it("Check DB config using password ", async () => {
 
 
 it("Check DB config using database parameter ", async () => {
-    const globalConfig = require("../../tests/configs/default.js");
     const dummyMysqlConfig = {
         host: "127.0.0.1",
         user: "root",
@@ -75,7 +71,6 @@ it("Check DB config using database parameter ", async () => {
 
 
 it("Check seven part config ", async () => {
-    const globalConfig = require("../../tests/configs/default.js");
     const dummyMysqlConfig = {
         host: "127.0.0.1",
         port: 3306,

--- a/__tests__/setupHooks/loadSetupHooks.js
+++ b/__tests__/setupHooks/loadSetupHooks.js
@@ -28,7 +28,7 @@ it("Should load setup hooks", async () => {
 });
 
 it("Should fail to load not async/promise based methods", async () => {
-    jest.mock("../../setupHooks", () => {
+    jest.doMock("../../setupHooks", () => {
         return {
             postSetup: () => {}
         };

--- a/databaseSetup.js
+++ b/databaseSetup.js
@@ -37,6 +37,9 @@ function importCreationScript(mysqlConfig, creationScriptPath) {
         if ("password" in mysqlConfig && mysqlConfig.password.length > 0) {
             params.push(`-p${mysqlConfig.password}`);
         }
+        if ("port" in mysqlConfig ) {
+            params.push(`-P ${mysqlConfig.port}`);
+        }
         //sql import to database: database_name < creation_script_path
         params.push(mysqlConfig.database);
         params.push(`< ${creationScriptPath}`);

--- a/default-config.js
+++ b/default-config.js
@@ -1,6 +1,7 @@
 module.exports = {
     databaseOptions: {
         host: "127.0.0.1",
+        port: 3306,
         user: "root",
         password: "root",
         database: "jest_mysql_test",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "debug": "^4.2.0"
   },
   "peerDependencies": {
-    "jest": "25.x.x",
+    "jest": "26.x.x",
     "mysql": "2.x.x"
   },
   "devDependencies": {

--- a/tests/configs/default.js
+++ b/tests/configs/default.js
@@ -1,6 +1,7 @@
 module.exports = {
     databaseOptions: {
         host: "127.0.0.1",
+        port: 3306,
         user: "root",
         password: "root",
         database: "jest_mysql_test",

--- a/tests/configs/providedSchema.js
+++ b/tests/configs/providedSchema.js
@@ -1,6 +1,7 @@
 module.exports = {
     databaseOptions: {
         host: "127.0.0.1",
+        port: 3306,
         user: "root",
         password: "root",
         database: "jest_mysql_test",

--- a/tests/configs/truncateEnabled.js
+++ b/tests/configs/truncateEnabled.js
@@ -1,6 +1,7 @@
 module.exports = {
     databaseOptions: {
         host: "127.0.0.1",
+        port: 3306,
         user: "root",
         password: "root",
         database: "jest_mysql_test",


### PR DESCRIPTION
As many do, I run mysql in docker on alternative ports, so the port parameter must be set in jest-mysql-config.
This change adds the -P <port> parameter to the mysql command line