### PR TITLE
docs(): Add MySQL port to config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ I.E.
 module.exports = {
   databaseOptions: {
     host: "localhost",
+    port: 3306
     user: "root",
     password: "",
     database: "test"


### PR DESCRIPTION
## What this PR Addresses?
- [x] Updates default config example with modifiable port for MySQL 